### PR TITLE
Feature: Chatbot support

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -429,6 +429,7 @@ export class Client extends EventEmitter<ToTuples<ClientEvents>> {
 			display: tags.displayName,
 			badges: tags.badges,
 			badgeInfo: tags.badgeInfo,
+			isBot: tags.badges.has('bot-badge'),
 			isBroadcaster: tags.badges.has('broadcaster'),
 			isMod: tags.mod,
 			isSubscriber: tags.subscriber,

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -23,6 +23,7 @@ function getUser(tags: irc.PRIVMSG.Tags | irc.USERNOTICE.Tags) {
 		display: tags.displayName,
 		badges: tags.badges,
 		badgeInfo: tags.badgeInfo,
+		isBot: tags.badges.has('bot-badge'),
 		isBroadcaster: tags.badges.has('broadcaster'),
 		isMod: tags.mod,
 		isSubscriber: tags.subscriber,

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -12,6 +12,7 @@ export type PrefixFull = Record<keyof PrefixHostOnly, string>;
 
 type KnownBadges =
 	| 'bits'
+	| 'bot-badge'
 	| 'broadcaster'
 	| 'founder'
 	| 'moderator'

--- a/src/twitch/events.ts
+++ b/src/twitch/events.ts
@@ -23,6 +23,7 @@ interface UserExtra extends User {
 	color: string;
 	badges: Badges;
 	badgeInfo: BadgeInfo;
+	isBot: boolean;
 	isBroadcaster: boolean;
 	isMod: boolean;
 	isSubscriber: boolean;


### PR DESCRIPTION
- Support the new [Chatbot badge](https://dev.twitch.tv/docs/chat/#chatbot-badge-and-chat-identity) by adding 'bot-badge' to the known badges
- Adds a `isBot` boolean flag to the User object